### PR TITLE
fix: #26 check the route info is iterable or not

### DIFF
--- a/packages/swagger/jest.config.js
+++ b/packages/swagger/jest.config.js
@@ -2,4 +2,5 @@ module.exports = {
   preset: 'ts-jest',
   testPathIgnorePatterns: ['<rootDir>/test/fixtures'],
   coveragePathIgnorePatterns: ['<rootDir>/test/'],
+  setupFilesAfterEnv: ['./jest.setup.js']
 };

--- a/packages/swagger/jest.setup.js
+++ b/packages/swagger/jest.setup.js
@@ -1,0 +1,1 @@
+jest.setTimeout(30000);

--- a/packages/swagger/src/lib/generator.ts
+++ b/packages/swagger/src/lib/generator.ts
@@ -65,13 +65,15 @@ export class SwaggerMetaGenerator {
       module
     );
 
-    for (const webRouter of webRouterInfo) {
-      let url = (prefix + webRouter.path).replace('//', '/');
-      url = replaceUrl(url, parseParamsInPath(url));
-      const router = new SwaggerDocumentRouter(webRouter.requestMethod, url);
-      router.tags = [tag.name];
-      this.generateRouter(webRouter, router, module);
-      this.document.addRouter(router);
+    if (webRouterInfo && typeof webRouterInfo[Symbol.iterator] === 'function') {
+      for (const webRouter of webRouterInfo) {
+        let url = (prefix + webRouter.path).replace('//', '/');
+        url = replaceUrl(url, parseParamsInPath(url));
+        const router = new SwaggerDocumentRouter(webRouter.requestMethod, url);
+        router.tags = [tag.name];
+        this.generateRouter(webRouter, router, module);
+        this.document.addRouter(router);
+      }
     }
   }
 

--- a/packages/swagger/test/fixtures/base-app/src/controller/empty.ts
+++ b/packages/swagger/test/fixtures/base-app/src/controller/empty.ts
@@ -1,0 +1,8 @@
+import { Provide, Controller } from '@midwayjs/decorator';
+
+@Provide()
+@Controller('/empty')
+export class EmptyController {
+  // dont delete me, for empty router info test purpose
+  // dont add any route in this controller
+}

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -4,6 +4,7 @@ import { IMidwayKoaApplication } from '@midwayjs/koa';
 describe('/test/feature.test.ts', () => {
 
   describe('test new features', () => {
+
     let app: IMidwayKoaApplication;
     beforeAll(async () => {
       app = await createApp('base-app', {}, '@midwayjs/koa');
@@ -36,7 +37,7 @@ describe('/test/feature.test.ts', () => {
       expect(swaggerData).toMatch('This is a swagger-ui for midwayjs project');
 
       // tag
-      expect(swaggerJSON.tags.length).toEqual(2);
+      expect(swaggerJSON.tags.length).toEqual(3);
       expect(swaggerJSON.tags).toContainEqual({
         'name': 'default',
         'description': 'default'
@@ -44,6 +45,10 @@ describe('/test/feature.test.ts', () => {
       expect(swaggerJSON.tags).toContainEqual({
         'name': 'user',
         'description': 'user'
+      });
+      expect(swaggerJSON.tags).toContainEqual({
+        'name': 'empty',
+        'description': 'empty'
       });
 
       // paths
@@ -53,6 +58,7 @@ describe('/test/feature.test.ts', () => {
       expect(swaggerJSON.paths).toHaveProperty('/login');
       expect(swaggerJSON.paths).toHaveProperty('/user/{userId}');
       expect(swaggerJSON.paths).toHaveProperty('/user/');
+      expect(swaggerJSON.paths).not.toHaveProperty('/empty/');
 
       expect(swaggerJSON.paths['/list']['get']['tags'][0]).toEqual('default');
       expect(swaggerJSON.paths['/list']['get']['parameters'].length).toEqual(2);
@@ -108,6 +114,7 @@ describe('/test/feature.test.ts', () => {
       expect(swaggerData).toMatch('UpdateDTO');
       expect(swaggerData).toMatch('"roles":{"type":"array","items":{"type":"string"}}');
     });
+
   });
 
 });


### PR DESCRIPTION
加了个判断，访问空的控制器造成 swagger-ui/json 报错，导致 swagger 不可用，因为 getClassMetadata 的内部 map#get 可能返回 undefined，该函数并不能确保返回 iterable 对象.