### PR TITLE
feat: swagger upgrade

### DIFF
--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
+    "jest": "node --require=ts-node/register ../../node_modules/jest/bin/jest.js",
     "test": "node --require=ts-node/register ../../node_modules/.bin/jest",
     "cov": "node --require=ts-node/register ../../node_modules/.bin/jest --coverage --forceExit"
   },

--- a/packages/swagger/src/controller/swagger.ts
+++ b/packages/swagger/src/controller/swagger.ts
@@ -31,7 +31,9 @@ export class SwaggerController {
 
   constructor() {
     const { getAbsoluteFSPath } = safeRequire('swagger-ui-dist');
-    this.swaggerUiAssetPath = getAbsoluteFSPath();
+    if (getAbsoluteFSPath) {
+      this.swaggerUiAssetPath = getAbsoluteFSPath();
+    }
   }
 
   @Get('/json')

--- a/packages/swagger/src/lib/createAPI.ts
+++ b/packages/swagger/src/lib/createAPI.ts
@@ -21,6 +21,7 @@ export interface APIParamFormat {
   deprecated?: boolean;
   allowEmptyValue?: boolean;
   example?: any;
+  $ref?: string;
 }
 
 export interface APIPropertyFormat {

--- a/packages/swagger/src/lib/generator.ts
+++ b/packages/swagger/src/lib/generator.ts
@@ -309,10 +309,12 @@ export class SwaggerMetaGenerator {
       case 'array':
         define.minItems = min;
         define.maxItems = max;
-        define.items = this.generateSwaggerByJoiProperty(
-          joiSchema.$_terms.items[0],
-          pathName
-        );
+        if (joiSchema.$_terms.items[0]) {
+          define.items = this.generateSwaggerByJoiProperty(
+            joiSchema.$_terms.items[0],
+            pathName
+          );
+        }
     }
     return define;
   }

--- a/packages/swagger/test/fixtures/base-app/src/controller/user.ts
+++ b/packages/swagger/test/fixtures/base-app/src/controller/user.ts
@@ -33,17 +33,23 @@ export class UserDTO {
   @Rule(RuleType.string().required())
   name: string;
 
-  @CreateApiPropertyDoc('年龄')
-  @Rule(RuleType.number())
+  // @CreateApiPropertyDoc('年龄')
+  @Rule(RuleType.number().description('年龄'))
   age: number;
 
-  @CreateApiPropertyDoc('学校信息')
+  // @CreateApiPropertyDoc('学校信息')
   @Rule(SchoolDTO)
   school: SchoolDTO;
 
   @CreateApiPropertyDoc('学校列表')
   @Rule(SchoolDTO)
   schoolList: SchoolDTO[];
+
+  @Rule(RuleType.number().valid(1,2,3).description('类型'))
+  type?: number;
+
+  @Rule(RuleType.number().forbidden())
+  testAttr?: number;
 }
 
 

--- a/packages/swagger/test/index.test.ts
+++ b/packages/swagger/test/index.test.ts
@@ -101,8 +101,17 @@ describe('/test/feature.test.ts', () => {
             '$ref': '#/components/schemas/SchoolDTO',
           },
           'schoolList': {
-            '$ref': '#/components/schemas/Array',
+            'type': 'array',
+            'description': '学校列表',
+            'items': {
+              '$ref': '#/components/schemas/SchoolDTO'
+            }
           },
+          type:{
+            'type': 'number',
+            'description':'类型',
+            'enum': [1,2,3]
+          }
         },
         'required': [
           'name',
@@ -116,7 +125,8 @@ describe('/test/feature.test.ts', () => {
       expect(swaggerData).not.toMatch('学校信息');
       expect(swaggerData).toMatch('标题参数');
       expect(swaggerData).toMatch('UpdateDTO');
-      expect(swaggerData).toMatch('"roles":{"type":"array","items":{"type":"string"}}');
+      expect(swaggerData).toMatch('"roles":{"type":"array","items":{"type":"string","maxLength":10}}');
+      expect(swaggerData).not.toMatch('testAttr')
     });
 
   });


### PR DESCRIPTION
https://github.com/midwayjs/midway/issues/1251

- 修复没有安装swagger-ui-dist时访问文档意外报错的问题
- 支持从dto获取字段描述，默认值，例子信息
- 过滤了forbidden的字段
- 支持获取dto字段的最大最小值，枚举值信息
- 支持从dto生成object类型字段的文档
- 支持从dto生成array类型字段的详细文档

基于以上功能，可以生成更为完善的接口文档，并且几乎不必再写任何dto的swagger装饰器了
